### PR TITLE
Task 1 get next 5 busses for stop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Created by https://www.gitignore.io/api/visualstudio
 
 ### VisualStudio ###
@@ -12,6 +11,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+**/*/appsettings*.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/BusBoard.ConsoleApp/BusBoard.ConsoleApp.csproj
+++ b/BusBoard.ConsoleApp/BusBoard.ConsoleApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,5 +8,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RestSharp" Version="112.1.1-alpha.0.4" />
+  </ItemGroup>
 
 </Project>

--- a/BusBoard.ConsoleApp/BusBoard.ConsoleApp.csproj
+++ b/BusBoard.ConsoleApp/BusBoard.ConsoleApp.csproj
@@ -7,9 +7,12 @@
     <AssemblyName>BusBoard.ConsoleApp</AssemblyName>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>d3490a8f-e855-472a-ad82-2b5f4ca9d5a9</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />
     <PackageReference Include="RestSharp" Version="112.1.1-alpha.0.4" />
   </ItemGroup>
 

--- a/BusBoard.ConsoleApp/Program.cs
+++ b/BusBoard.ConsoleApp/Program.cs
@@ -1,1 +1,18 @@
-Console.WriteLine("Welcome to BusBoard Console App!");
+using System.Net;
+using BusBoard.ConsoleApp;
+using BusBoard.ConsoleApp.TflModels;
+public class Program
+{
+	private static void LoadMenu()
+	{
+		Console.Clear();
+		Console.WriteLine("🚌 Welcome To Bus Board");
+	}
+	public static void Main(string[] args)
+	{
+		ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+		LoadMenu();
+		TflApiService tflApiClient = new TflApiService();
+		var predictions = tflApiClient.GetApiResponse<List<Prediction>>("StopPoint/490005911W/Arrivals");
+	}
+}

--- a/BusBoard.ConsoleApp/Program.cs
+++ b/BusBoard.ConsoleApp/Program.cs
@@ -1,12 +1,12 @@
 using System.Net;
 using BusBoard.ConsoleApp.TflApiService;
 using BusBoard.ConsoleApp.TflModels;
+using Microsoft.Extensions.Configuration;
 
 public class Program
 {
 	private static void LoadMenu()
 	{
-		Console.Clear();
 		Console.WriteLine("## Welcome To Bus Board ##");
 	}
 
@@ -34,7 +34,12 @@ public class Program
 	{
 		ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 		
-		Actions tflActions = new Actions();
+		var config = new ConfigurationBuilder()
+			.AddJsonFile("appsettings.json", optional: true)
+			.AddEnvironmentVariables()
+			.Build();
+		
+		Actions tflActions = new Actions(config);
 		LoadMenu();
 
 		var userInputStopId = RequestUserForStopID();

--- a/BusBoard.ConsoleApp/Program.cs
+++ b/BusBoard.ConsoleApp/Program.cs
@@ -1,18 +1,45 @@
 using System.Net;
-using BusBoard.ConsoleApp;
+using BusBoard.ConsoleApp.TflApiService;
 using BusBoard.ConsoleApp.TflModels;
+
 public class Program
 {
 	private static void LoadMenu()
 	{
 		Console.Clear();
-		Console.WriteLine("🚌 Welcome To Bus Board");
+		Console.WriteLine("## Welcome To Bus Board ##");
 	}
+
+	public static string RequestUserForStopID()
+	{
+		string userInput = "";
+		do
+		{
+			Console.WriteLine("Enter the bus stop id: ");
+			userInput = Console.ReadLine();
+		} while (userInput is null || userInput.Trim().Length == 0);
+
+		return userInput;
+	}
+
+	public static void DisplayBusPredictions(List<Prediction> predictions)
+	{
+		foreach (var prediction in predictions)
+		{
+			Console.WriteLine($"Route: {prediction.LineName} | Destination: {prediction.DestinationName} | ETA: {prediction.TimeToStation}s");
+		}
+	}
+
 	public static void Main(string[] args)
 	{
 		ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+		
+		Actions tflActions = new Actions();
 		LoadMenu();
-		TflApiService tflApiClient = new TflApiService();
-		var predictions = tflApiClient.GetApiResponse<List<Prediction>>("StopPoint/490005911W/Arrivals");
+
+		var userInputStopId = RequestUserForStopID();
+		var prediction = tflActions.GetUpToNextFiveBusPredictionsAtStop(userInputStopId);
+		DisplayBusPredictions(prediction);
+
 	}
 }

--- a/BusBoard.ConsoleApp/TflApiService.cs
+++ b/BusBoard.ConsoleApp/TflApiService.cs
@@ -1,0 +1,43 @@
+﻿using RestSharp;
+using RestSharp.Serializers.Json;
+
+namespace BusBoard.ConsoleApp;
+
+public class TflApiService
+{
+    private readonly RestClient _client;
+    
+    public TflApiService()
+    {
+        RestClientOptions options = new RestClientOptions("https://api.tfl.gov.uk/");
+        _client = new RestClient(
+            options,
+            configureSerialization: s => s.UseSystemTextJson());
+        // TODO: Add api secret - this will run when no secret set with high rate limiting 
+        _client.AddDefaultParameter("app_id", "");
+    }
+    
+    public T GetApiResponse<T>(string resource)
+    {
+        var request = new RestRequest(resource);
+        var response = _client.Execute<T>(request);
+
+        if (response.StatusCode != System.Net.HttpStatusCode.OK)
+        {
+            throw new Exception($"Something went wrong." +
+                                $"status code: '{response.StatusCode}' on TFL API request: '{resource}'"); 
+        }
+        
+        // Console.WriteLine(response.Content);
+
+        if (response.Data == null)
+        {
+            throw new Exception($"Something went wrong. on TFL API request: '{resource}'" +
+                                $"status code: '{response.StatusCode}' but data is null. Failed to deserialize."); 
+        }
+
+        T responseRecords = response.Data;
+
+        return responseRecords;
+    }
+}

--- a/BusBoard.ConsoleApp/TflApiService/Actions.cs
+++ b/BusBoard.ConsoleApp/TflApiService/Actions.cs
@@ -1,10 +1,16 @@
 ﻿namespace BusBoard.ConsoleApp.TflApiService;
 using BusBoard.ConsoleApp.TflModels;
+using Microsoft.Extensions.Configuration;
 
 
 public class Actions
 {
-    private readonly TflApiClient _tflApiClient = new TflApiClient();
+    private readonly TflApiClient _tflApiClient;
+
+    public Actions(IConfiguration secretOptions)
+    {
+        _tflApiClient = new TflApiClient(secretOptions);
+    }
 
     public List<Prediction> GetUpToNextFiveBusPredictionsAtStop(string stopId)
     {

--- a/BusBoard.ConsoleApp/TflApiService/Actions.cs
+++ b/BusBoard.ConsoleApp/TflApiService/Actions.cs
@@ -1,0 +1,15 @@
+﻿namespace BusBoard.ConsoleApp.TflApiService;
+using BusBoard.ConsoleApp.TflModels;
+
+
+public class Actions
+{
+    private readonly TflApiClient _tflApiClient = new TflApiClient();
+
+    public List<Prediction> GetUpToNextFiveBusPredictionsAtStop(string stopId)
+    {
+        var predictions = _tflApiClient.GetApiResponse<List<Prediction>>($"StopPoint/{stopId}/Arrivals");
+        predictions = predictions.OrderBy(x => x.TimeToStation).Take(5).ToList();
+        return predictions;
+    }
+}

--- a/BusBoard.ConsoleApp/TflApiService/TflApiClient.cs
+++ b/BusBoard.ConsoleApp/TflApiService/TflApiClient.cs
@@ -1,5 +1,7 @@
 ﻿using RestSharp;
 using RestSharp.Serializers.Json;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Configuration;
 
 namespace BusBoard.ConsoleApp.TflApiService;
 
@@ -7,14 +9,14 @@ public class TflApiClient
 {
     private readonly RestClient _client;
     
-    public TflApiClient()
+    public TflApiClient(IConfiguration secretConfiguration)
     {
         RestClientOptions options = new RestClientOptions("https://api.tfl.gov.uk/");
         _client = new RestClient(
             options,
             configureSerialization: s => s.UseSystemTextJson());
-        // TODO: Add api secret - this will run when no secret set with high rate limiting 
-        _client.AddDefaultParameter("app_id", "");
+        
+        _client.AddDefaultParameter("app_id",secretConfiguration["TflApi.AppKey"]);
     }
     
     public T GetApiResponse<T>(string resource)

--- a/BusBoard.ConsoleApp/TflApiService/TflApiClient.cs
+++ b/BusBoard.ConsoleApp/TflApiService/TflApiClient.cs
@@ -1,13 +1,13 @@
 ﻿using RestSharp;
 using RestSharp.Serializers.Json;
 
-namespace BusBoard.ConsoleApp;
+namespace BusBoard.ConsoleApp.TflApiService;
 
-public class TflApiService
+public class TflApiClient
 {
     private readonly RestClient _client;
     
-    public TflApiService()
+    public TflApiClient()
     {
         RestClientOptions options = new RestClientOptions("https://api.tfl.gov.uk/");
         _client = new RestClient(
@@ -28,8 +28,6 @@ public class TflApiService
                                 $"status code: '{response.StatusCode}' on TFL API request: '{resource}'"); 
         }
         
-        // Console.WriteLine(response.Content);
-
         if (response.Data == null)
         {
             throw new Exception($"Something went wrong. on TFL API request: '{resource}'" +

--- a/BusBoard.ConsoleApp/TflModels/Prediction.cs
+++ b/BusBoard.ConsoleApp/TflModels/Prediction.cs
@@ -1,0 +1,91 @@
+﻿namespace BusBoard.ConsoleApp.TflModels;
+using System.Text.Json.Serialization;
+public class Prediction
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("operationType")]
+    public int OperationType { get; set; }
+
+    [JsonPropertyName("vehicleId")]
+    public string VehicleId { get; set; }
+
+    [JsonPropertyName("naptanId")]
+    public string NaptanId { get; set; }
+
+    [JsonPropertyName("stationName")]
+    public string StationName { get; set; }
+
+    [JsonPropertyName("lineId")]
+    public string LineId { get; set; }
+
+    [JsonPropertyName("lineName")]
+    public string LineName { get; set; }
+
+    [JsonPropertyName("platformName")]
+    public string PlatformName { get; set; }
+
+    [JsonPropertyName("direction")]
+    public string Direction { get; set; }
+
+    [JsonPropertyName("bearing")]
+    public string Bearing { get; set; }
+
+    [JsonPropertyName("tripId")]
+    public string TripId { get; set; }
+
+    [JsonPropertyName("baseVersion")]
+    public string BaseVersion { get; set; }
+
+    [JsonPropertyName("destinationNaptanId")]
+    public string DestinationNaptanId { get; set; }
+
+    [JsonPropertyName("destinationName")]
+    public string DestinationName { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public DateTime Timestamp { get; set; }
+
+    [JsonPropertyName("timeToStation")]
+    public int TimeToStation { get; set; }
+
+    [JsonPropertyName("currentLocation")]
+    public string CurrentLocation { get; set; }
+
+    [JsonPropertyName("towards")]
+    public string Towards { get; set; }
+
+    [JsonPropertyName("expectedArrival")]
+    public DateTime ExpectedArrival { get; set; }
+
+    [JsonPropertyName("timeToLive")]
+    public DateTime TimeToLive { get; set; }
+
+    [JsonPropertyName("modeName")]
+    public string ModeName { get; set; }
+
+    [JsonPropertyName("timing")]
+    public PredictionTiming Timing { get; set; }
+}
+
+public class PredictionTiming
+{
+    [JsonPropertyName("countdownServerAdjustment")]
+    public string CountdownServerAdjustment { get; set; }
+
+    [JsonPropertyName("source")]
+    public DateTime Source { get; set; }
+
+    [JsonPropertyName("insert")]
+    public DateTime Insert { get; set; }
+
+    [JsonPropertyName("read")]
+    public DateTime Read { get; set; }
+
+    [JsonPropertyName("sent")]
+    public DateTime Sent { get; set; }
+
+    [JsonPropertyName("received")]
+    public DateTime Received { get; set; }
+}


### PR DESCRIPTION
## Introduction :pencil2:
Implimentation for [Part 1 - BusBoard training exersize](https://softwiretech.atlassian.net/wiki/spaces/Academy/pages/1566705030/3+-+BusBoard+C#Part-1%3A-Bus-Times). This PR adds a command line interface where a user can enter a bus stop id `stopId`, which is used to display the 5 next upcoming busses to that stop.

## Resolution :heavy_check_mark:
- Add `TflApiClient` to request the `tfl` Unified API and parse the response.
- Add an `Prediction` model to represent the returned data structure for parsing.
- Add `GetUpToNextFiveBusPredictionsAtStop` method in a `Actions` class to get the required data.
- Add functionality for users to enter a `stop Id` and display the requested data.

## Screenshots :camera_flash:
Example of successful usage:

<img width="679" height="281" alt="image" src="https://github.com/user-attachments/assets/7c034286-8f9b-4d93-bff7-aa7454ca4cb3" />

## Miscellaneous :heavy_plus_sign:
- You may need to add your TFL API secret - however you can still run the application without with high rate limiting.
- If the user enters a invalid `stop Id`, the program will raise a exception rather than catch the error

## Note :warning:
- Missing tests.