### PR TITLE
NST925-15 fix static file routing for /Content and /Scripts folder

### DIFF
--- a/BusBoard.Web/Program.cs
+++ b/BusBoard.Web/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.FileProviders;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -14,6 +15,20 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(
+        Path.Combine(builder.Environment.ContentRootPath, "Content")),
+    RequestPath = "/Content"
+});
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(
+        Path.Combine(builder.Environment.ContentRootPath, "Scripts")),
+    RequestPath = "/Scripts"
+});
 
 app.UseRouting();
 


### PR DESCRIPTION
## Introduction :pencil2:

Currently, static files such as `CSS` and `JS` are returning a 'not found' error when the page is visited.

## Problem example :camera_flash:

Homepage where scripts and `CSS` haven’t loaded:
<img width="1638" height="683" alt="image" src="https://github.com/user-attachments/assets/721928cb-1fca-401f-b941-f333809b70fb" />


Network logs which show the static files are not found:
<img width="1104" height="294" alt="image" src="https://github.com/user-attachments/assets/e9190f59-e379-48ce-aef5-c2a10d7197e1" />


## Resolution :heavy_check_mark:

Add the folders `/Content` and `/Scripts` which contain the missing static files to the config using [app.UseStaticFiles - Docs](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/static-files?view=aspnetcore-9.0#serve-files-outside-of-the-web-root-directory-via-usestaticfiles).

Homepage after Fix:
<img width="3275" height="1280" alt="image" src="https://github.com/user-attachments/assets/9d3a0362-363a-497f-acbf-a3251e39fe05" />

Network logs successfully finding missing files:
<img width="1322" height="353" alt="image" src="https://github.com/user-attachments/assets/f0d8ed72-05d9-43f8-9676-f561b641a453" />

## Miscellaneous :heavy_plus_sign:
None

## Note :warning:
None

Ticket: [NST925-15](https://softwiretech.atlassian.net/browse/NST925-15)